### PR TITLE
Respect limit argument in fixedpoint enumeration.

### DIFF
--- a/mpbn/__init__.py
+++ b/mpbn/__init__.py
@@ -236,7 +236,7 @@ class MPBooleanNetwork(minibn.BooleanNetwork):
             the given constraints.
         :param int limit: maximum number of solutions, ``0`` for unlimited.
         """
-        s = clingo_enum()
+        s = clingo_enum(limit=limit)
         s.add("base", [], self.asp_of_bn())
         e = "fp"
         t2 = "fp"

--- a/tests/test_fixpoints.py
+++ b/tests/test_fixpoints.py
@@ -20,3 +20,5 @@ class TestFixedpoints(unittest.TestCase):
         self.assertEqual(fps, self.all_fps)
     def test_reachable(self):
         self.assertEqual(len(list(self.mbn.fixedpoints(reachable_from=self.ci))), 1)
+    def test_limit(self):
+        self.assertEqual(len(list(self.mbn.fixedpoints(limit=1))), 1)


### PR DESCRIPTION
Just a super-minor bugfix :) 

Fixed-point enumeration was by accident ignoring the `limit` argument. This should fixed it.